### PR TITLE
Raise error on search backend failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1275,14 +1275,6 @@ If you use `DatabaseCleaner` in your tests with [the `transaction` strategy](htt
 Chewy.use_after_commit_callbacks = !Rails.env.test?
 ```
 
-## Running specs
-
-Make sure you're running a local Elasticsearch instance.
-
-```
-ES_PORT=9200 bundle exec rspec
-```
-
 ## Contributing
 
 1. Fork it (http://github.com/toptal/chewy/fork)

--- a/README.md
+++ b/README.md
@@ -1275,6 +1275,14 @@ If you use `DatabaseCleaner` in your tests with [the `transaction` strategy](htt
 Chewy.use_after_commit_callbacks = !Rails.env.test?
 ```
 
+## Running specs
+
+Make sure you're running a local Elasticsearch instance.
+
+```
+ES_PORT=9200 bundle exec rspec
+```
+
 ## Contributing
 
 1. Fork it (http://github.com/toptal/chewy/fork)

--- a/lib/chewy/errors.rb
+++ b/lib/chewy/errors.rb
@@ -36,4 +36,7 @@ module Chewy
       super("`#{join_field_type}` set for the join field `#{join_field_name}` is not on the :relations list (#{relations})")
     end
   end
+
+  class MissingHitsInScrollError < Error
+  end
 end

--- a/lib/chewy/errors.rb
+++ b/lib/chewy/errors.rb
@@ -39,4 +39,7 @@ module Chewy
 
   class ImportScopeCleanupError < Error
   end
+
+  class MissingHitsInScrollError < Error
+  end
 end

--- a/lib/chewy/search/scrolling.rb
+++ b/lib/chewy/search/scrolling.rb
@@ -34,6 +34,9 @@ module Chewy
         scroll_id = nil
 
         loop do
+          failures = result.dig('_shards', 'failures')
+          raise Chewy::Error, failures if failures.present?
+
           hits = result.fetch('hits', {}).fetch('hits', [])
           fetched += hits.size
           hits = hits.first(last_batch_size) if last_batch_size != 0 && fetched >= total

--- a/lib/chewy/search/scrolling.rb
+++ b/lib/chewy/search/scrolling.rb
@@ -29,19 +29,25 @@ module Chewy
 
         result = perform(size: batch_size, scroll: scroll)
         total = [raw_limit_value, result.fetch('hits', {}).fetch('total', {}).fetch('value', 0)].compact.min
+
+        total_batches = total / batch_size
         last_batch_size = total % batch_size
-        fetched = 0
+        total_batches += 1 if last_batch_size != 0
+
         scroll_id = nil
 
-        loop do
+        total_batches.times do |batch_counter|
+          last_run = total_batches - 1 == batch_counter
+
           hits = result.fetch('hits', {}).fetch('hits', [])
-          fetched += hits.size
-          hits = hits.first(last_batch_size) if last_batch_size != 0 && fetched >= total
+          hits = hits.first(last_batch_size) if last_run && last_batch_size != 0
+
+          raise Chewy::MissingHitsInScrollError if hits.empty?
+
           yield(hits) if hits.present?
           scroll_id = result['_scroll_id']
-          break if fetched >= total
 
-          result = perform_scroll(scroll: scroll, scroll_id: scroll_id)
+          result = perform_scroll(scroll: scroll, scroll_id: scroll_id) unless last_run
         end
       ensure
         Chewy.client.clear_scroll(body: {scroll_id: scroll_id}) if scroll_id

--- a/lib/chewy/version.rb
+++ b/lib/chewy/version.rb
@@ -1,3 +1,3 @@
 module Chewy
-  VERSION = '7.6.0'.freeze
+  VERSION = '7.4.0'.freeze
 end

--- a/spec/chewy/search/scrolling_spec.rb
+++ b/spec/chewy/search/scrolling_spec.rb
@@ -33,6 +33,56 @@ describe Chewy::Search::Scrolling, :orm do
     let(:countries) { Array.new(3) { |i| Country.create!(rating: i + 2, name: "country #{i}") } }
 
     describe '#scroll_batches' do
+      describe 'with search backend returning failures' do
+        before do
+          expect(Chewy.client).to receive(:scroll).once.and_return(
+            'hits' => {
+              'total' => {
+                'value' => 5
+              },
+              'hits' => []
+            },
+            '_shards' => {
+              'total' => 5,
+              'successful' => 2,
+              'skipped' => 0,
+              'failed' => 3,
+              'failures' => [
+                {
+                  'shard' => -1,
+                  'index' => nil,
+                  'reason' => {
+                    'type' => 'search_context_missing_exception',
+                    'reason' => 'No search context found for id [34462229]'
+                  }
+                },
+                {
+                  'shard' => -1,
+                  'index' => nil,
+                  'reason' => {
+                    'type' => 'search_context_missing_exception',
+                    'reason' => 'No search context found for id [34462228]'
+                  }
+                },
+                {
+                  'shard' => -1,
+                  'index' => nil,
+                  'reason' => {
+                    'type' => 'search_context_missing_exception',
+                    'reason' => 'No search context found for id [34888662]'
+                  }
+                }
+              ]
+            },
+            '_scroll_id' => 'scroll_id'
+          )
+        end
+
+        specify do
+          expect { request.scroll_batches(batch_size: 2) {} }.to raise_error(Chewy::Error)
+        end
+      end
+
       context do
         before { expect(Chewy.client).to receive(:scroll).twice.and_call_original }
         specify do

--- a/spec/chewy/search/scrolling_spec.rb
+++ b/spec/chewy/search/scrolling_spec.rb
@@ -79,7 +79,7 @@ describe Chewy::Search::Scrolling, :orm do
         end
 
         specify do
-          expect { request.scroll_batches(batch_size: 2) {} }.to raise_error(Chewy::Error)
+          expect { request.scroll_batches(batch_size: 2) {} }.to raise_error(Chewy::MissingHitsInScrollError)
         end
       end
 


### PR DESCRIPTION

This pull request introduces a new error handling mechanism for missing hits during scroll operations in the `Chewy` library. It includes the definition of a custom error class, updates to the scrolling logic, and corresponding test cases to ensure the changes work as expected.

### Error Handling Enhancements:
* Introduced a new custom error class, `MissingHitsInScrollError`, in `lib/chewy/errors.rb` to handle cases where no hits are returned during a scroll operation.
* Updated the `scroll_batches` method in `lib/chewy/search/scrolling.rb` to raise the `MissingHitsInScrollError` when the backend returns empty hits, ensuring the error is handled explicitly.

### Test Coverage:
* Added test cases in `spec/chewy/search/scrolling_spec.rb` to simulate scenarios where the search backend fails and returns no hits. These tests verify that the `MissingHitsInScrollError` is raised appropriately. [[1]](diffhunk://#diff-a97d9799da8f6a0e38cbd021d69676c23cffc84c22b1206a704e35efc357206fR36-R85) [[2]](diffhunk://#diff-a97d9799da8f6a0e38cbd021d69676c23cffc84c22b1206a704e35efc357206fR184-R233)

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
