### PR TITLE
Merge scroll fix into master such that we can update Chewy in core to 7.6.0

### DIFF
--- a/lib/chewy/errors.rb
+++ b/lib/chewy/errors.rb
@@ -39,4 +39,7 @@ module Chewy
 
   class ImportScopeCleanupError < Error
   end
+
+  class MissingHitsInScrollError < Error
+  end
 end

--- a/lib/chewy/search/scrolling.rb
+++ b/lib/chewy/search/scrolling.rb
@@ -34,6 +34,9 @@ module Chewy
         scroll_id = nil
 
         loop do
+          failures = result.dig('_shards', 'failures')
+          raise Chewy::Error, failures if failures.present?
+
           hits = result.fetch('hits', {}).fetch('hits', [])
           fetched += hits.size
           hits = hits.first(last_batch_size) if last_batch_size != 0 && fetched >= total

--- a/lib/chewy/version.rb
+++ b/lib/chewy/version.rb
@@ -1,3 +1,3 @@
 module Chewy
-  VERSION = '7.6.0'.freeze
+  VERSION = '7.6.0.h1.1'.freeze
 end

--- a/spec/chewy/search/scrolling_spec.rb
+++ b/spec/chewy/search/scrolling_spec.rb
@@ -33,6 +33,56 @@ describe Chewy::Search::Scrolling, :orm do
     let(:countries) { Array.new(3) { |i| Country.create!(rating: i + 2, name: "country #{i}") } }
 
     describe '#scroll_batches' do
+      describe 'with search backend returning failures' do
+        before do
+          expect(Chewy.client).to receive(:scroll).once.and_return(
+            'hits' => {
+              'total' => {
+                'value' => 5
+              },
+              'hits' => []
+            },
+            '_shards' => {
+              'total' => 5,
+              'successful' => 2,
+              'skipped' => 0,
+              'failed' => 3,
+              'failures' => [
+                {
+                  'shard' => -1,
+                  'index' => nil,
+                  'reason' => {
+                    'type' => 'search_context_missing_exception',
+                    'reason' => 'No search context found for id [34462229]'
+                  }
+                },
+                {
+                  'shard' => -1,
+                  'index' => nil,
+                  'reason' => {
+                    'type' => 'search_context_missing_exception',
+                    'reason' => 'No search context found for id [34462228]'
+                  }
+                },
+                {
+                  'shard' => -1,
+                  'index' => nil,
+                  'reason' => {
+                    'type' => 'search_context_missing_exception',
+                    'reason' => 'No search context found for id [34888662]'
+                  }
+                }
+              ]
+            },
+            '_scroll_id' => 'scroll_id'
+          )
+        end
+
+        specify do
+          expect { request.scroll_batches(batch_size: 2) {} }.to raise_error(Chewy::Error)
+        end
+      end
+
       context do
         before { expect(Chewy.client).to receive(:scroll).twice.and_call_original }
         specify do

--- a/spec/chewy/search/scrolling_spec.rb
+++ b/spec/chewy/search/scrolling_spec.rb
@@ -79,7 +79,7 @@ describe Chewy::Search::Scrolling, :orm do
         end
 
         specify do
-          expect { request.scroll_batches(batch_size: 2) {} }.to raise_error(Chewy::Error)
+          expect { request.scroll_batches(batch_size: 2) {} }.to raise_error(Chewy::MissingHitsInScrollError)
         end
       end
 


### PR DESCRIPTION
## Overview

This cherry picks the two commits from tomdev/raise-error-on-search-backend-failure that are custom functionality on top of Chewy. The goal here is to retain the changes while also allowing elastic search to go above 7.14 as specified in the master gemspec. 
This is related to the failed pipeline here: https://gitlab.inverselink.com/hackerone/engineering_and_product/core/-/jobs/31850105

## Goal

Use a modern Chewy base while preserving existing H1 behavior, so downstream apps can update Elasticsearch/Faraday dependencies without losing this safety check.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
